### PR TITLE
ルビと親文字を一文字として生成するオプションの追加（EU4対応）

### DIFF
--- a/furigana_font_maker.py
+++ b/furigana_font_maker.py
@@ -50,7 +50,8 @@ def main():
     dst_font = sys.argv[4]
 
     # ルビ文字のサイズ
-    furigana_scale = 0.5
+    furigana_scale = 0.15
+#   furigana_scale = 0.5
 
     # 生成後のフォントのサイズ
     ascent_scale = 1.0
@@ -61,7 +62,9 @@ def main():
     # 全ての文字の高さの調整量
     all_glyph_height = -200
 
-    new_furigana_codepoint = 0xE000
+    # EU4SpecialEscapeとの干渉を避けるため
+    new_furigana_codepoint = 0xF000
+#   new_furigana_codepoint = 0xE000
 
     symbol_oyamoji_left   = u"｜"
     symbol_oyamoji_right  = u"《"
@@ -134,12 +137,16 @@ def main():
             # このルビ指定が既出であれば、それを使い回す
             if text_oyamoji_furigana in dictionary_oyamoji_furigana:
 
+                #### ルビと親文字を一文字にするので親文字を残さない
                 # ルビの指定部分を置換し、出力用の文字列を作成する（一カ所ずつ処理するので、replaceの回数を1に）
                 temp_furigana_codepoint = dictionary_oyamoji_furigana[text_oyamoji_furigana]
-                src_text_line = src_text_line.replace(text_oyamoji_furigana, text_oyamoji + unichr(temp_furigana_codepoint), 1)
+                src_text_line = src_text_line.replace(text_oyamoji_furigana, unichr(temp_furigana_codepoint), 1)
+#               src_text_line = src_text_line.replace(text_oyamoji_furigana, text_oyamoji + unichr(temp_furigana_codepoint), 1)
 
+            # ルビと漢字をセットで一文字にするので、処理を飛ばす
+            elif False:
             # 親文字の幅とルビが既出のものがあれば、それを使い回す
-            elif width_and_furigana in dictionary_width_furigana:
+#           elif width_and_furigana in dictionary_width_furigana:
 
                 # ルビの指定部分を置換し、出力用の文字列を作成する（一カ所ずつ処理するので、replaceの回数を1に）
                 temp_furigana_codepoint = dictionary_width_furigana[width_and_furigana]
@@ -177,11 +184,25 @@ def main():
                         furigana_codepoint = ord(furigana)
                         font[new_furigana_codepoint].addReference(font[furigana_codepoint].glyphname , matrix)
 
-                # ルビ文字の幅をゼロに（親文字の後ろにつけるので）
-                font[new_furigana_codepoint].width = 0;
+                # ルビに親文字を加えて一文字にする
+                for index, oyamoji in enumerate(list(text_oyamoji)):
+                    if index == 0:
+                        # 親文字の一文字目だけは、文字の位置とサイズを設定して参照を追加
+                        matrix = psMat.compose(psMat.scale(1.0), psMat.translate(-oyamoji_width, 0.0))
+                        oyamoji_codepoint = ord(oyamoji)
+                        font[new_furigana_codepoint].addReference(font[oyamoji_codepoint].glyphname , matrix)
+                    else:
+                        # 親文字の二文字目以降は読み捨て
+                        break
 
+                #### ルビと親文字を一文字にするのでコメントアウト
+                # ルビ文字の幅をゼロに（親文字の後ろにつけるので）
+#               font[new_furigana_codepoint].width = 0;
+
+                #### ルビと親文字を一文字にするので親文字を残さない
                 # ルビの指定部分を置換し、出力用の文字列を作成する（一カ所ずつ処理するので、replaceの回数を1に）
-                src_text_line = src_text_line.replace(text_oyamoji_furigana, text_oyamoji + unichr(new_furigana_codepoint), 1)
+                src_text_line = src_text_line.replace(text_oyamoji_furigana, unichr(new_furigana_codepoint), 1)
+#               src_text_line = src_text_line.replace(text_oyamoji_furigana, text_oyamoji + unichr(new_furigana_codepoint), 1)
 
                 # ルビ文字を割り当てるコードポイントを次へ
                 new_furigana_codepoint += 1

--- a/furigana_font_maker.py
+++ b/furigana_font_maker.py
@@ -57,7 +57,6 @@ def main():
     option_onechar      = False
     option_nofurigana   = False
     target_eu4          = False
-    target_eu4alt       = False
 
     if scaling == None:
         scaling = 0.5


### PR DESCRIPTION
「Europa Universalis IV」（以下、EU4）のマップフォントに応用するため、
ルビと親文字を一文字として生成するオプションを追加しました。

EU4のマップは、国名が一文字ずつ分割されて自動配置される仕様になっています。
この仕様に対応するため、ルビと親文字を一文字に合成したフォントを
私的領域に生成するオプション --one-character を追加しました。

また、同じ文字列（国名）がマップ上ではなくテキスト中に出現した場合に対応するため、
ルビを合成せず、親文字だけを同じ文字コードで私的領域に生成するオプション
--one-character-no-furigana も追加しています。

[EU4の日本語化](https://github.com/matanki-saito/EU4dll)では、私的領域の 0x0E00～0x0EFF を[別の用途に使用](https://github.com/matanki-saito/EU4fontcreate)しています。
そのため、ルビ付き文字の生成開始位置を 0x0F00 にずらすオプション --eu4 を追加しました。

加えて、ルビの縮尺をフォントに応じて動的に変更する必要があったため、
縮尺を引数として受け取る修正も施しました。

以上をまとめると、コマンドラインオプションは次のように拡張されます。

第5引数（省略可）・・・ルビの縮尺（浮動小数点数、デフォルトは0.5）
第6引数（省略可）・・・ルビの生成方式（--one-character または --one-character-no-furigana）
第7引数（省略可）・・・ターゲット（現在は --eu4 のみ）

オプションの指定方法および解析ルーチンは暫定的なものです。
kengo700さまの志向に応じて好きなように改変していただいて構いません。

サンプル画像
![furigana 4a](https://user-images.githubusercontent.com/42687608/51880824-11be0380-23bc-11e9-9f63-d628656ec9ff.jpg)